### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 - Improve python plugin load order (prevents crashes when python does not load correctly)
 - Add in safe IDA process termination (Special thanks to @tmr232 for this)
 
-#What and Why?
+# What and Why?
 This is a plugin to embed an IPython kernel in IDA Pro. The Python ecosystem has amazing libraries (and communities) for scientific computing. IPython itself is great for exploratory data analysis. Using tools such as the IPython notebook make it easy to share code and explanations with rich media. IPython makes using IDAPython and interacting with IDA programmatically really fun and easy.
 
-##Example Uses
-##QT Console
+## Example Uses
+## QT Console
 You can just use IPython qtconsole for a better interactive python shell for IDA.
 
 ![Image of Basic QT Usage](qtbasic.gif)
@@ -16,7 +16,7 @@ You can also use the QT console to graph things. This is an example creating a b
 
 ![Image of QT with graph](qtwithgraph.gif)
 
-###Notebooks
+### Notebooks
 
 Another useful case is using IPython notebooks.
 
@@ -26,28 +26,28 @@ Another useful case is using IPython notebooks.
 
 More examples..soon...
 
-#How the plugin works
+# How the plugin works
 IDA is predominantly single threaded application, so we cannot safely run the kernel in a separate thread. So instead of using another thread a hook is created on the QT process events function and the `do_one_iteration` method of the ipython kernel is executed each frame.
 
-#Installation
+# Installation
 I suggest using the [Anaconda](http://continuum.io/downloads) distribution of Python as it comes with all the required python libraries pre-built and installed. To get IDA to use Anaconda, simply set the PYTHONHOME enviroment variable. Alternatively you can install IPython and the dependencies separately.
 
 This plugin should work on all 6.X x86 QT versions of IDA on Windows.
 
-##Basic Installation and QTConsole
+## Basic Installation and QTConsole
 1. Download and extract the [release](https://github.com/james91b/ida_ipython/releases/latest)
 2. Copy the contents of the `plugins` and `python` directories under IDA's installation directory.
 4. Launch IDA.
 5. At the command line (Windows), start an IPython qtconsole with the kernel instance (outputted in the IDA console) e.g `ipython qtconsole --existing kernel-4264.json`
 
-##Using the Notebook
+## Using the Notebook
 1. Copy `idc` directory to your IDA directory. (the `nothing.idc` script is used to pass command line parameters to the plugin)
 2. Change the paths to the `idaq.exe` and `idaq64.exe` executables in the `kernel.json` under the `notebook\kernels\ida32`
     and `notebook\kernels\ida64` directories respectively
 3. Install the kernels using `jupyter-kernelspec install` (e.g. `jupyter-kernelspec install --user notebook\kernels\ida64`)
 4. When starting a notebook, choose the `IDA32` or `IDA64` kernels, depending on your desired IDA version.
 
-#How to Build
+# How to Build
 1. Install cmake
 2. At the command line cd to the root directory and run the following
 3. `mkdir build`
@@ -59,7 +59,7 @@ e.g.
 
 So far only tested with "Visual Studio 11" compiler.
 
-#Changelog
+# Changelog
 0.5
 - Improve python plugin load order (prevents crashes when python does not load correctly)
 - Add in safe IDA process termination (Special thanks to @tmr232 for this)
@@ -79,6 +79,6 @@ So far only tested with "Visual Studio 11" compiler.
 0.1
 - First release
 
-#To do/Future Ideas
+# To do/Future Ideas
 - More examples
 - Create a library for cell/line magic functions specific to IDA


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
